### PR TITLE
fix-#16

### DIFF
--- a/core/auth/signin/auth-service.signin.factory.js
+++ b/core/auth/signin/auth-service.signin.factory.js
@@ -1,17 +1,18 @@
 module.exports = dependencies => (event, data) => {
 
-    const persistence = dependencies.persistence;
-    const crypto = dependencies.crypto;
+    const loadMasterKey = dependencies.loadMasterKey;
+    const setPlainTextPassword = dependencies.setPlainTextPassword;
+    const hash = dependencies.hash;
 
-    let masterKey = persistence.loadMasterKey();
+    let masterKey = loadMasterKey();
     let readKey = masterKey.readKey;
-    let hash = crypto.hash(readKey.salt, data);
+    let givenPasswordHash = hash(readKey.salt, data);
 
-    if (hash.content === readKey.key) {
-        persistence.setPlainTextPassword(data);
+    if (givenPasswordHash.content === readKey.key) {
+        setPlainTextPassword(data);
         return { status: 200 }; // request ok
     }
-    
+
     return { status: 500, errorMessage: 'Wrong credentials' }; // wrong credentials
 
 }

--- a/core/auth/signin/auth-service.signin.test.js
+++ b/core/auth/signin/auth-service.signin.test.js
@@ -1,3 +1,49 @@
-test('dummy test', () => {
-    expect(true).toEqual(true);
+const factory = require('./auth-service.signin.factory.js');
+
+test('signin_fail', () => {
+    const loadMasterKey = jest.fn( () => {
+        return {
+            readKey: {
+                key: "",
+                salt: 0,
+                iv: 0,
+                lastUpdate: 0
+            },
+            writeKey: {
+                key: "",
+                salt: 0,
+                iv: 0,
+                lastUpdate: 0
+            }
+        }
+    });
+
+    const setPlainTextPassword = jest.fn();
+    const hash = jest.fn( (salt, data) => { return {salt: salt, content: hash}});
+    const signinService = factory({loadMasterKey, setPlainTextPassword, hash});
+    expect(signinService("abc")).toEqual({ status: 500, errorMessage: 'Wrong credentials' });
+})
+
+test('signin_ok', () => {
+    const loadMasterKey = jest.fn( () => {
+        return {
+            readKey: {
+                key: "d3104dc9a6f8a7dab0e0e86560f74dc9b84a84a24c3508dce2eb2c6b9a35beaf",
+                salt: 3,
+                iv: 0,
+                lastUpdate: 0
+            },
+            writeKey: {
+                key: "",
+                salt: 0,
+                iv: 0,
+                lastUpdate: 0
+            }
+        }
+    });
+
+    const setPlainTextPassword = jest.fn();
+    const hash = jest.fn( (salt, data) => { return {salt: 3, content: "d3104dc9a6f8a7dab0e0e86560f74dc9b84a84a24c3508dce2eb2c6b9a35beaf"}});
+    const signinService = factory({loadMasterKey, setPlainTextPassword, hash});
+    expect(signinService("foobar")).toEqual({ status: 200});
 })

--- a/core/auth/signin/index.js
+++ b/core/auth/signin/index.js
@@ -1,6 +1,9 @@
 const factory = require('./auth-service.signin.factory.js');
 const persistence = require("../../persistence/index.js");
 const crypto = require("../../crypto/index.js");
-const signin = factory({persistence, crypto});
+const loadMasterKey = persistence.loadMasterKey;
+const setPlainTextPassword = persistence.setPlainTextPassword;
+const hash = crypto.hash;
+const signin = factory({loadMasterKey, setPlainTextPassword, hash});
 
 module.exports = signin;


### PR DESCRIPTION
 - esplicitate le dipendeze per la signin factory, ora questa non riceve più per interi i moduli `persistence` e `crypto`, ma si limita a ricevere le funzioni dalle quali dipende. Questo come suggerito semplifica le operazioni di mocking e di conseguenza la testabilità del codice.
 - aggiunti un paio di test (signin_ok e signin_fail) che possono servire da modello su come utilizzare il mocking e conseguentemente creare il servizio
