### PR TITLE
fix-#38-mapping-form-wallet-item-con-oggetto

### DIFF
--- a/view/src/app/authenticated/wallet-item/wallet-item.component.html
+++ b/view/src/app/authenticated/wallet-item/wallet-item.component.html
@@ -11,39 +11,20 @@
 
     <div formArrayName="credentials">
         <h3>Credentials</h3>
-        <div *ngFor="let credential of credentials.controls; let i = index">
-            <!-- method required for cast restriction-->
-           <app-form-key-value [item]="getCredentialsFormGroupAt(i)"></app-form-key-value> 
-        </div>
-        
-        <div>
-            <app-form-key-value [item]="newCredentialGroup"></app-form-key-value> 
-            <button (click)="addCredential()">add</button>
+        <div *ngFor="let credential of credentials.controls; let last = last">
+           <app-form-key-value (addClicked)="addCredential()" [showAdd]="last" [item]="credential"></app-form-key-value> 
         </div>
     </div>
     <hr>
 
     <div formArrayName="secrets">
         <h3>Secrets</h3>
-        <div class="secret-item" *ngFor="let secret of secrets.controls; let i = index">
-            <app-form-key-value [item]="getSecretFormGroupAt(i)"></app-form-key-value> 
-        </div>
-        <div >
-            <app-form-key-value [item]="newSecretGroup"></app-form-key-value> 
-            <button (click)="addSecret()">add</button>
+        <div class="secret-item" *ngFor="let secret of secrets.controls; let last = last">
+            <app-form-key-value (addClicked)="addSecret()" [showAdd]="last" [item]="secret"></app-form-key-value> 
         </div>
     </div>
 
-    <!--<button (click)="suggestOne()">Suggest one</button>-->
-    
     <div class="secret-suggestion">
-        <!--
-        <label for="pass-opt">password</label>
-        <input type="radio" id="pass-opt" name="secret-type-select" (change)="suggestPassword()" checked>
-        <label for="pin-opt">pin</label>
-        <input type="radio" id="pin-opt" name="secret-type-select" (change)="suggestPin()">
-        <input type="number" name="" id="" min="1" max="8" [formControl]="pinLength">
-        -->
         <app-password-generator (passwordGenerated)="onPasswordGenerated($event)"></app-password-generator>
         {{suggested_secret}}
     </div>

--- a/view/src/app/dummies/form-key-value/form-key-value.component.html
+++ b/view/src/app/dummies/form-key-value/form-key-value.component.html
@@ -2,4 +2,5 @@
     <input type="text" formControlName="name">
     <span>:</span>
     <input type="text" formControlName="value">
+    <button [disabled]="!isGroupDirty()" (click)="onAddClicked()" *ngIf="showAdd">Add</button>
 </div>

--- a/view/src/app/dummies/form-key-value/form-key-value.component.ts
+++ b/view/src/app/dummies/form-key-value/form-key-value.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { AbstractControl, FormBuilder, FormGroup } from '@angular/forms';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormBuilder, } from '@angular/forms';
 
 @Component({
   selector: 'app-form-key-value',
@@ -8,13 +8,23 @@ import { AbstractControl, FormBuilder, FormGroup } from '@angular/forms';
 })
 export class FormKeyValueComponent {
 
-  @Input() item: FormGroup;
+  @Input() item: any;
+  @Input() showAdd = false;
+  @Output() addClicked = new EventEmitter<boolean>();
 
   constructor(private fb: FormBuilder) { 
     this.item = this.fb.group({
       name: [''],
       value: ['']
     });
+  }
+
+  isGroupDirty() {
+    return this.item.get('name')?.value && this.item.get('value')?.value;
+  }
+
+  onAddClicked() {
+    this.addClicked.emit(true);
   }
 
 }

--- a/view/src/app/interfaces.ts
+++ b/view/src/app/interfaces.ts
@@ -1,0 +1,38 @@
+/**
+ * Pensato come punto comodo per oggetti di estensione. Inserire qui solamente
+ * classi ed interfacce pensate come estensione al framework e quindi non 
+ * specifiche per l'applicazione
+ */
+
+ import {
+    AbstractControl,
+    AbstractControlOptions,
+    AsyncValidatorFn,
+    FormArray,
+    FormBuilder,
+    ValidatorFn
+  } from "@angular/forms";
+  
+  export class DynamicFormArrayControl extends FormArray {
+  
+    constructor(controls: AbstractControl[], private fb: FormBuilder, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null) {
+      super(controls, validatorOrOpts, asyncValidator);
+    }
+  
+    resize(value: any[]) {
+      value.forEach((newValue, index) => {
+        if (typeof newValue === 'object'){
+          this.push(this.fb.group(newValue));
+        } else if (Array.isArray(newValue)) {
+          this.push(new DynamicFormArrayControl([], this.fb));
+        } else {
+          this.push(this.fb.control({}));
+        }
+      });
+    }
+    setValue(value: any[], options?: { onlySelf?: boolean; emitEvent?: boolean }) {
+      this.resize(value);
+      super.setValue(value, options);
+    }
+  }
+


### PR DESCRIPTION
sommario interventi:

- aggiunta classe per mapping dinamico iniziale: in angular ogni controller ha bisogno che il valore passato nel setValue abbia forma e dimensioni attese. Quando riceviamo un dato da un servizio non possiamo sapere in anticipo la dimensione di un array, la classe creata serve a superare questo problema.
- eliminati formGroup di appoggio: i formGroup servivano solo come appoggio temp per poi essere copiati all'interno dell'array, questo rendeva necessario anche il side-effect del reset di questi controlli quando si aggiunge una credenziale o un segreto. Con l'intervento il click sull'add permette di creare uno slot vuoto che viene tradotto come formGroup all'interno del formArray.
- refactor del componente app-form-key-value: ora è questo che è in grado di sapere se è dirty o meno ed eventualmente mostrare un bottone di add